### PR TITLE
SQLite & PostgreSQL Support 

### DIFF
--- a/.db_bridge.cfg.example
+++ b/.db_bridge.cfg.example
@@ -3,15 +3,21 @@
 active = mysql
 
 [mysql]
+driver   = mysql
 host     = localhost
 port     = 3306
-name     = dbname
+database = dbname
 user     = username
 password = supersecret
 
+[sqlite]
+driver   = sqlite
+database = /full/path/to/local.db
+
 ; [postgres]
+; driver   = postgres
 ; host     = db.example.com
 ; port     = 5432
-; name     = otherdb
+; database = otherdb
 ; user     = admin
 ; password = hunter2

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-# copy to `.env` and fill in
-DB_HOST=localhost
-DB_NAME=dbname
-DB_USER=username
-DB_PASS=supersecret
-
-# optional override:
-# DB_PORT=3306
-# DB_BRIDGE_PROFILE=mysql

--- a/db_bridge/__init__.py
+++ b/db_bridge/__init__.py
@@ -1,3 +1,5 @@
+# db_bridge/__init__.py
+
 from importlib.metadata import version
 
 __version__ = version("db-bridge")   # reads pyproject.toml metadata

--- a/db_bridge/base_utils.py
+++ b/db_bridge/base_utils.py
@@ -1,0 +1,79 @@
+# db_bridge/base_utils.py
+
+from typing import List, Any, Optional, Union, Tuple
+
+try:
+    from colorfulPyPrint.py_color import print_exception
+except ImportError:
+    def print_exception(e):
+        pass
+
+
+class BaseBridge:
+    """
+    Base class for database bridges. Handles common run_sql, commit, and fetch logic.
+    """
+    def __init__(self, creds: dict, as_dict: bool = False) -> None:
+        self.creds = creds
+        self.as_dict = as_dict
+        self.conn = None
+        self.cursor = None
+
+    def _prepare_sql(self, sql: str, params: list) -> Tuple[str, List[Any]]:
+        """
+        Driver-specific SQL preprocessing (e.g. placeholder translation).
+        Override in subclasses if needed.
+        """
+        return sql, params
+
+    def run_sql(
+            self,
+            sql: str,
+            params: Optional[List[Any]] = None
+    ) -> Union[List[dict], List[tuple]]:
+        """
+        Execute a SQL statement using the underlying cursor, with optional parameters.
+
+        This method:
+          1) Lets the subclass preprocess the SQL and params (e.g. placeholder translation).
+          2) Executes the query.
+          3) Fetches results as a list of rows (dicts if `as_dict=True`, otherwise tuples).
+          4) Commits the transaction.
+
+        Args:
+            sql:    The SQL string to execute (may include ? or %s placeholders).
+            params: Optional list of parameters to bind to the query.
+
+        Returns:
+            A list of rows, each row as a dict (if `self.as_dict`) or tuple.
+        """
+        # 1) SQL preprocessing
+        sql, params = self._prepare_sql(sql, params or [])
+
+        # 2) Execute
+        self.cursor.execute(sql, params)
+
+        # 3) Fetch
+        if self.as_dict and getattr(self.cursor, "description", None):
+            cols = [col[0] for col in self.cursor.description]
+            rows = [dict(zip(cols, row)) for row in self.cursor.fetchall()]
+        else:
+            rows = self.cursor.fetchall()
+
+        # 4) Commit and return
+        self.conn.commit()
+        return rows
+
+    def get_last_row_id(self):
+        return getattr(self.cursor, "lastrowid", None)
+
+    def get_row_count(self):
+        return getattr(self.cursor, "rowcount", None)
+
+    def close(self):
+        try:
+            self.cursor.close()
+            self.conn.close()
+        except Exception as e:
+            print_exception(e)
+            pass

--- a/db_bridge/config.py
+++ b/db_bridge/config.py
@@ -1,49 +1,47 @@
+# db_bridge/config.py
+
 import configparser
 import os
 from pathlib import Path
-
-from dotenv import load_dotenv
-
-# Optional: load a .env file if python-dotenv is installed
-try:
-    load_dotenv()
-except ImportError:
-    pass
+from typing import Dict, Any
 
 
-def load_config(profile_env_var: str = "DB_BRIDGE_PROFILE") -> dict:
+def load_config(profile_name: str = None) -> Dict[str, Any]:
     """
-    1) ENV-first: if DB_NAME/DB_USER/DB_PASS are set in .env, use those.
-    2) INI fallback: look for ~/.db_bridge.cfg, where ~ comes from HOME or USERPROFILE.
-       Section = [DEFAULT].active or first section.
-    Returns a dict: host, port, database, user, password
-    """
-    # 1) ENV-first
-    name = os.getenv("DB_NAME")
-    user = os.getenv("DB_USER")
-    pwd = os.getenv("DB_PASS")
-    if name and user and pwd:
-        return {
-            "host": os.getenv("DB_HOST", "localhost"),
-            "port": int(os.getenv("DB_PORT", 3306)),
-            "database": name,
-            "user": user,
-            "password": pwd,
-        }
+    Load DB credentials from ~/.db_bridge.cfg, or (if set and exists) from $DB_BRIDGE_CONFIG.
 
-    # 2) INI fallback
-    home_dir = Path(os.getenv("HOME") or os.getenv("USERPROFILE") or Path.home())
-    cfg_path = home_dir / ".db_bridge.cfg"
-    if not cfg_path.exists():
+    Args:
+        profile_name: Name of the section to load. If None, uses [DEFAULT].active or the first section.
+
+    Environment:
+        DB_BRIDGE_CONFIG: path to an alternate .cfg file (used only if that file exists).
+    """
+
+    # 1) Determine config file path
+    cfg_env = os.getenv("DB_BRIDGE_CONFIG", "").strip()
+    if cfg_env and Path(cfg_env).is_file():
+        cfg_path = Path(cfg_env)
+    else:
+        home = os.getenv("HOME") or os.getenv("USERPROFILE") or None
+        base = Path(home) if home else Path.home()
+        cfg_path = base / ".db_bridge.cfg"
+
+    if not cfg_path.is_file():
         raise RuntimeError(
-            "No DB config found: set DB_NAME/DB_USER/DB_PASS in ENV, "
-            "or create ~/.db_bridge.cfg"
+            f"No DB config found at {cfg_path}. "
+            "Please create ~/.db_bridge.cfg or set DB_BRIDGE_CONFIG correctly."
         )
 
+    # 2) Parse the file
     cfg = configparser.ConfigParser()
     cfg.read(cfg_path)
 
-    active = os.getenv(profile_env_var) or cfg["DEFAULT"].get("active", None)
+    # 3) Pick the profile/section
+    if profile_name:
+        active = profile_name
+    else:
+        active = cfg["DEFAULT"].get("active", None)
+
     if not active:
         sections = cfg.sections()
         if not sections:
@@ -54,10 +52,25 @@ def load_config(profile_env_var: str = "DB_BRIDGE_PROFILE") -> dict:
         raise RuntimeError(f"Profile '{active}' not found in {cfg_path}")
 
     sect = cfg[active]
-    return {
-        "host": sect.get("host", "localhost"),
-        "port": int(sect.get("port", '3306')),
-        "database": sect["name"],
-        "user": sect["user"],
-        "password": sect["password"],
-    }
+
+    # 4) Build creds dict
+    driver = sect.get("driver", "mysql").lower()
+    creds = {"driver": driver}
+
+    if driver == "sqlite":
+        db_path = sect.get("database") or sect.get("path")
+        if not db_path:
+            raise RuntimeError(
+                f"SQLite profile '{active}' requires a 'database = /path/to/file.db'"
+            )
+        creds["database"] = db_path
+    else:
+        creds.update({
+            "host": sect.get("host", fallback="localhost"),
+            "port": sect.getint("port", fallback=(5432 if driver == "postgres" else 3306)),
+            "database": sect.get("database") or sect.get("name"),
+            "user": sect["user"],
+            "password": sect["password"],
+        })
+
+    return creds

--- a/db_bridge/mysql_utils.py
+++ b/db_bridge/mysql_utils.py
@@ -1,0 +1,33 @@
+# db_bridge/mysql_utils.py
+
+import pymysql
+import pymysql.cursors
+
+from .base_utils import BaseBridge
+
+
+class MySQLBridge(BaseBridge):
+    """
+    MySQL adapter for db-bridge, using PyMySQL under the hood.
+
+    Expects creds dict keys:
+        - host, port, user, password, database
+    """
+
+    def __init__(self, creds: dict, as_dict: bool = False) -> None:
+        """
+        Initialize a MySQL connection.
+
+        Args:
+            creds:   Dict with connection parameters:
+                     host, port, user, password, database, (driver ignored).
+            as_dict: If True, returns each row as a dict; otherwise as tuple.
+        """
+        super().__init__(creds, as_dict)
+        # Choose the cursor class
+        cursor_cls = pymysql.cursors.DictCursor if as_dict else pymysql.cursors.Cursor
+        # Establish the connection
+        conn_args = {k: v for k, v in creds.items() if k != "driver"}
+        self.conn = pymysql.connect(cursorclass=cursor_cls, **conn_args)
+        # Create a cursor for executing queries
+        self.cursor = self.conn.cursor()

--- a/db_bridge/postgres_utils.py
+++ b/db_bridge/postgres_utils.py
@@ -1,0 +1,34 @@
+# db_bridge/postgres_utils.py
+
+import psycopg2
+import psycopg2.extras
+from .base_utils import BaseBridge
+
+
+class PostgresBridge(BaseBridge):
+    """
+    PostgreSQL adapter for db-bridge, using psycopg2 under the hood.
+    """
+
+    def __init__(self, creds: dict, as_dict: bool = False) -> None:
+        """
+        Args:
+            creds:   Dict with keys host, port, user, password, database.
+            as_dict: If True, returns rows as dicts; otherwise tuples.
+        """
+        super().__init__(creds, as_dict)
+        # Choose cursor factory
+        cursor_factory = psycopg2.extras.DictCursor if as_dict else None
+        # Establish connection
+        conn_args = {
+            "host": creds["host"],
+            "port": creds["port"],
+            "user": creds["user"],
+            "password": creds["password"],
+            "dbname": creds["database"],
+            "cursor_factory": cursor_factory
+        }
+        self.conn = psycopg2.connect(**conn_args)
+        self.cursor = self.conn.cursor()
+
+    # No placeholder translation needed—psycopg2 also uses %s

--- a/db_bridge/sqlite_utils.py
+++ b/db_bridge/sqlite_utils.py
@@ -1,0 +1,41 @@
+# db_bridge/sqlite_utils.py
+
+import sqlite3
+from pathlib import Path
+from typing import Tuple, List, Any
+
+from .base_utils import BaseBridge
+
+
+class SQLiteBridge(BaseBridge):
+    """
+    SQLite adapter for db-bridge, using the built-in sqlite3 module.
+    """
+
+    def __init__(self, creds: dict, as_dict: bool = False) -> None:
+        """
+        Initialize an SQLite connection, creating parent directories if needed.
+
+        Args:
+            creds:   Dict with at least 'database' (path to .db file), plus 'driver'.
+            as_dict: If True, returns each row as a dict; otherwise as tuple.
+        """
+        super().__init__(creds, as_dict)
+
+        db_path = creds["database"]
+        # Ensure the directory exists so sqlite can create the file
+        parent = Path(db_path).parent
+        parent.mkdir(parents=True, exist_ok=True)
+        # Open (and create) the SQLite file
+        self.conn = sqlite3.connect(db_path)
+
+        # If the user wants dicts, set row_factory
+        if as_dict:
+            self.conn.row_factory = sqlite3.Row
+        self.cursor = self.conn.cursor()
+
+    def _prepare_sql(self, sql: str, params: list) -> Tuple[str, List[Any]]:
+        """
+        Translate MySQL-style %s placeholders into sqlite3 '?' placeholders.
+        """
+        return sql.replace("%s", "?"), params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [project]
 name = "db-bridge"
-version = "0.2.2"
-description = "Simple SQL connector — pass native SQL queries as strings with zero boilerplate."
+version = "0.3.0"
+description = """Minimal Python SQL connector with support for MySQL, SQLite, and PostgreSQL.
+Execute raw or parameterized queries with zero boilerplate.
+Manage multiple database profiles via a simple INI file (~/.db_bridge.cfg)
+"""
 readme = "README.md"
 authors = [{name = "Kanad Rishiraj (RoamingSaint)", email = "roamingsaint27@gmail.com"}]
 license = "MIT"
@@ -9,8 +12,8 @@ license-files = ["LICENSE"]
 requires-python = ">=3.7"
 dependencies = [
   "pymysql>=1.0",
-  "AskUser>=0.1.1",
-  "python-dotenv>=0.21"
+  "psycopg2-binary>=2.9",
+  "AskUser>=0.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,48 +1,50 @@
+# tests/test_config.py
+
 import pytest
 
-from db_bridge import config
+from db_bridge.config import load_config
 
 
-# clear any ENV vars that might interfere
 @pytest.fixture(autouse=True)
-def clear_env(monkeypatch):
-    for var in ("DB_NAME", "DB_USER", "DB_PASS", "DB_HOST", "DB_PORT", "DB_BRIDGE_PROFILE"):
-        monkeypatch.delenv(var, raising=False)
+def tmp_config(tmp_path, monkeypatch):
+    # Create a temp INI file
+    ini_path = tmp_path / "test_config.ini"
+    INI = """
+[DEFAULT]
+active = alpha
+
+[alpha]
+driver   = sqlite
+database = /tmp/alpha.db
+
+[bravo]
+driver   = mysql
+host     = localhost
+port     = 3306
+database = bravo_db
+user     = user
+password = pass
+"""
+    # Write the INI content directly
+    ini_path.write_text(INI)
+    # Point the loader at it
+    monkeypatch.setenv("DB_BRIDGE_CONFIG", str(ini_path))
+    return ini_path
 
 
-def test_env_override(monkeypatch):
-    monkeypatch.setenv("DB_NAME", "db1")
-    monkeypatch.setenv("DB_USER", "user1")
-    monkeypatch.setenv("DB_PASS", "pw1")
-    monkeypatch.setenv("DB_HOST", "h1")
-    monkeypatch.setenv("DB_PORT", "1234")
-
-    cfg = config.load_config()
-    assert cfg["database"] == "db1"
-    assert cfg["user"] == "user1"
-    assert cfg["password"] == "pw1"
-    assert cfg["host"] == "h1"
-    assert cfg["port"] == 1234
+def test_load_default():
+    creds = load_config()
+    assert creds["driver"] == "sqlite"
+    assert creds["database"] == "/tmp/alpha.db"
 
 
-def test_ini_fallback(tmp_path, monkeypatch):
-    # Create a fake ~/.db_bridge.cfg
-    ini = tmp_path / ".db_bridge.cfg"
-    ini.write_text(
-        "[DEFAULT]\n"
-        "active = prof1\n"
-        "[prof1]\n"
-        "host = localhost\n"
-        "port = 3307\n"
-        "name = db2\n"
-        "user = user2\n"
-        "password = pw2\n"
-    )
-    monkeypatch.setenv("HOME", str(tmp_path))
+def test_load_named_profile():
+    creds = load_config("bravo")
+    assert creds["driver"] == "mysql"
+    assert creds["host"] == "localhost"
+    assert creds["database"] == "bravo_db"
 
-    cfg = config.load_config()
-    assert cfg["database"] == "db2"
-    assert cfg["user"] == "user2"
-    assert cfg["password"] == "pw2"
-    assert cfg["host"] == "localhost"
-    assert cfg["port"] == 3307
+
+def test_missing_profile_raises():
+    with pytest.raises(RuntimeError):
+        load_config("charlie")


### PR DESCRIPTION
Code has been refactored to handle MYSQL, SQLite & PostgreSQL. 
Removed .env support and uses ~/.db_bridge.cfg (this can be overridden by $DB_BRIDGE_CONFIG if needed, but not recommended.
Multiple profiles can be supported by passing profile into run_sql()